### PR TITLE
Update sv.json

### DIFF
--- a/Localization/Data/sv.json
+++ b/Localization/Data/sv.json
@@ -1,6 +1,6 @@
 {
   "Recommended": "Rekommenderad",
-  "New Releases": "Nya Utsläpp",
+  "New Releases": "Nysläppta",
   "Sources": "Källor",
   "Packages": "Paket",
   "FileManager": "Filhanterare",
@@ -229,6 +229,8 @@
   "ti": "Tigrinska",
   "bo": "Tibetanska",
   "zh": "Kinesiska (Förenklad)",
+  "zh-CN": "Kinesiska (Förenklad, Folkrepubliken Kina)",
+  "zh_TW": "Kinesiska (Traditionell, Taiwan)",
   "ts": "Tsonga",
   "te": "Tegulu",
   "da": "Danska",
@@ -284,5 +286,7 @@
   "li": "Limburgiska",
   "ro": "Rumänska",
   "rm": "Rätoromanska",
-  "ru": "Ryska"
+  "ru": "Ryska",
+  "cs & sk": "Tjeckiska & Slovakiska",
+  "ca & es": "Katalanska & Spanska"
 }


### PR DESCRIPTION
Fixed some translations and added translation for the multiple language codes in the in-app list of translators (such as "cs & sk") which weren't included previously in the template and therefore didn't display the language names (should now hopefully display "Tjeckiska & Slovakiska" (= "Czech & Slovak")).